### PR TITLE
fixed issue#32

### DIFF
--- a/deployment/cdk.json
+++ b/deployment/cdk.json
@@ -1,8 +1,6 @@
 {
   "app": "python3 app.py",
   "context":{
-    "bda_runtime_endpoint":"",
-    "bda_endpoint":"",
     "blueprint_name":"claims-review-cms-1500",
     "claims_submission_bucket_name": "claims-submission",
     "claims_review_bucket_name": "claims-review",

--- a/deployment/stacks/claims_review_stack/document_automation.py
+++ b/deployment/stacks/claims_review_stack/document_automation.py
@@ -93,7 +93,7 @@ class DocumentAutomation(Construct):
             timeout=Duration.seconds(300),
             layers=[layer],
             environment={
-                'ENDPOINT':bda_endpoint,
+                 **({'ENDPOINT': bda_endpoint} if bda_endpoint is not None else {}),
                 'BLUEPRINT_NAME':blueprint_name
             }
         )


### PR DESCRIPTION
*Issue #, if available:* [Issue 32](https://github.com/aws-solutions-library-samples/guidance-for-multimodal-data-processing-using-amazon-bedrock-data-automation/issues/32)

*Description of changes:*
The root cause was that the ENDPOINT env variables in lambda was going in as "" instead of None. this was due to cdk.json containing the keys bda-runtime-endpoint and bda-endpoint parameters. The change was to remove these two keys from cdk.json. There was another related but that the None check pre lambda env config was missing for one Lambda function. That was also fixed.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
