### PR TITLE
fixed typo in lambda function definition. timeout attribute

### DIFF
--- a/deployment/stacks/claims_review_stack/database.py
+++ b/deployment/stacks/claims_review_stack/database.py
@@ -139,7 +139,7 @@ class Database(Construct):
             runtime=_lambda.Runtime.PYTHON_3_10,
             handler="index.handler",
             code=_lambda.Code.from_asset("lambda/claims_review/manage_schema"),
-            Duration=Duration.seconds(300),
+            timeout=Duration.seconds(300),
             environment={
                 "CLUSTER_ARN": cluster.cluster_arn,
                 "SECRET_ARN": cluster.secret.secret_arn,


### PR DESCRIPTION
*Issue #, if available:* [Issue 53](https://github.com/aws-solutions-library-samples/guidance-for-multimodal-data-processing-using-amazon-bedrock-data-automation/issues/53)

*Description of changes:*
the timeout parameter was mistyped as Duration causing stack to fail when running cdk deploy. Fixed by renaming the parameter to 'timeout' which is the right parameter for the Function construct.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
