### PR TITLE
fixed validation error with cdk commands

### DIFF
--- a/deployment/cdk.json
+++ b/deployment/cdk.json
@@ -5,6 +5,7 @@
     "database_name":"claimsdatabase",
     "claims_submission_bucket_name": "claims-submission",
     "claims_review_bucket_name": "claims-review",
+    "inference_profile_id": "us.amazon.nova-pro-v1:0",
     "agent":{
         "claims_review_agent_resource_role_name": "claims_review_agent_resource_role"
     },

--- a/deployment/docs/b_claims_review_01_deploy.md
+++ b/deployment/docs/b_claims_review_01_deploy.md
@@ -79,22 +79,10 @@ You can use a cross region inference profile in place of a foundation model to r
 
    ```
 5. Bootstrap AWS CDK (first-time only):
-   
-> [!Note]
-> You would need a model id or an inference profile id for this step. See [Select a Foundation Model](#select-a-foundation-model-to-use-with-bedrock-agent)
-
-   Using a foundation model 
-   ```bash
-   cdk bootstrap --context foundation_model_id=<<your_chosen_model_id>>
    ```
-   
-   Using an inference profile 
-   ```bash
-   cdk bootstrap  --context inference_profile_id=<<your_chosen_inference_profile_id>>
-   ```
-> [!Important]
-> You must provide one of foundation model id or inference profile id, but not both
+   cdk bootstrap
 
+   ```
 
 6. Go to the `layer` directory and install lambda layer dependencies into the `python` subdirectory:
    
@@ -104,24 +92,19 @@ You can use a cross region inference profile in place of a foundation model to r
    cd ../../..
 
    ```
-  
-7. Deploy the stack: <a name="deploy-the-stack"></a>
+7. Deploy the stack: <a name="deploy-the-stack"></a>. Please use a foundation model or an inference profile of your choice for this step. See [Select a Foundation Model](#select-a-foundation-model-to-use-with-bedrock-agent)
 
-> [!Note]
-> You would need a model id or an inference profile id for this step. See [Select a Foundation Model](#select-a-foundation-model-to-use-with-bedrock-agent)
-
-   Using a foundation model 
+   
+   Using a foundation model
    ```bash
    cdk deploy claims-review  --context foundation_model_id=<<your_chosen_model_id>>
-   ```
-   
-   Using an inference profile 
+   ```   
+   Using an inference profile
    ```bash
    cdk deploy claims-review  --context inference_profile_id=<<your_chosen_inference_profile_id>>
-   ```
+   ```   
 > [!Important]
 > You must provide one of foundation model id or inference profile id, but not both
-
 
 
    To protect you against unintended changes that affect your security posture, the CDK CLI prompts you to approve security-related changes before deploying them. When prompted, review the changes and Enter `y` for  `Do you wish to deploy these changes (y/n)?` if you intend to proceed.

--- a/deployment/stacks/claims_review_stack/agent.py
+++ b/deployment/stacks/claims_review_stack/agent.py
@@ -28,12 +28,6 @@ class ClaimsReviewAgentStack(Stack):
 
         foundation_model_id = self.node.try_get_context("foundation_model_id")
         inference_profile_id = self.node.try_get_context("inference_profile_id")
-
-        #raise exception if both foundation_model_id and inference_profile_id are not provided or if both are provided
-        if not foundation_model_id and not inference_profile_id:
-            raise ValueError("Please provide either foundation_model_id or inference_profile_id")
-        if foundation_model_id and inference_profile_id:
-            raise ValueError("Please provide only one of foundation_model_id or inference_profile_id")
         
         #Create a custom resource to get the inference profile
         model_arns=None


### PR DESCRIPTION
*Issue #, if available:* [#60](https://github.com/aws-solutions-library-samples/guidance-for-multimodal-data-processing-using-amazon-bedrock-data-automation/issues/60)

*Description of changes:* set default 1P inference profile in cdk.json


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
