### PR TITLE
Added fix for inference profile , claims-cli and claim_review_action_group

### DIFF
--- a/deployment/lambda/claims_review/claims_review_agent_actions/index.py
+++ b/deployment/lambda/claims_review/claims_review_agent_actions/index.py
@@ -290,18 +290,18 @@ def create_claim_service(event):
     response = {
         "claimId": claim_id,
         "claim_description": "Not Implemented"}
-    # services_text = get_request_property(event,"services")
-    # services = json.loads(services_text)
-    # print(services)
-    # for service in services: # type: ignore
-    #     parameters = [
-    #         create_param("date_of_service", get_request_property(event,"date_of_service")),
-    #         create_param("place_of_service", get_request_property(event,"place_of_service")),
-    #         create_param("type_of_service", get_request_property(event,"type_of_service")),
-    #         create_param("procedure_code", get_request_property(event,"procedure_code")),
-    #         create_param("amount", get_request_property(event,"charge_amount"))
-    #     ]
-    #     result = run_command(sql_statement=CREATE_SERVICE_QUERY, parameters=parameters)
+    services_text = get_request_property(event,"services")
+    services = json.loads(services_text)
+    print(services)
+    for service in services: # type: ignore
+        parameters = [
+            create_param("date_of_service", get_request_property(event,"date_of_service")),
+            create_param("place_of_service", get_request_property(event,"place_of_service")),
+            create_param("type_of_service", get_request_property(event,"type_of_service")),
+            create_param("procedure_code", get_request_property(event,"procedure_code")),
+            create_param("amount", get_request_property(event,"charge_amount"))
+        ]
+        result = run_command(sql_statement=CREATE_SERVICE_QUERY, parameters=parameters)
 
     return response
 

--- a/source/claims_review_app/claims-cli.py
+++ b/source/claims_review_app/claims-cli.py
@@ -10,6 +10,7 @@ import dateutil.parser
 import json
 import botocore
 from botocore.exceptions import CredentialRetrievalError, NoRegionError
+from typing import Union, Optional
 class ClaimsCLI:
     def __init__(self):
         try :
@@ -80,7 +81,7 @@ class ClaimsCLI:
         )
         return response['ingestionJob']['status']
 
-    def wait_for_start(self,bucket:str, key:str,timestamp, max_attempts=10, delay=5)-> None | str:
+    def wait_for_start(self,bucket:str, key:str,timestamp, max_attempts=10, delay=5)-> Optional[str]:
         attempts = 0
         while attempts < max_attempts:
             job = self.get_ingestion_job_for_document(bucket, key, timestamp)


### PR DESCRIPTION
*Issue #, if available:*
3 issues - IAM Policy syntax issue for inference profile failing,
 claims-cli.sh upload-eoc-document failing
"error": "claim_review_action_group::/claims/{claim_id}/service is not a valid API, try another one

*Description of changes:*

Added checks 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
